### PR TITLE
Feature/multi braille cells

### DIFF
--- a/src/enamel/BrailleCell.java
+++ b/src/enamel/BrailleCell.java
@@ -53,7 +53,7 @@ public class BrailleCell {
 	private void initializeAlphabet() {
 		alphabet.put('a', "10000000");
 		alphabet.put('b', "11000000");
-		alphabet.put('c', "10100000");
+		alphabet.put('c', "10010000");
 		alphabet.put('d', "10011000");
 		alphabet.put('e', "10001000");
 		alphabet.put('f', "11010000");

--- a/src/enamel/TactilePlayer.java
+++ b/src/enamel/TactilePlayer.java
@@ -125,7 +125,7 @@ public class TactilePlayer extends Player {
     public void refresh() {
         try {
             STROBE.low();
-            for (int i = 0; i < brailleList.size(); i++) {
+            for (int i = brailleList.size() - 1; i >= 0; i--) {
                 for (int j = brailleList.get(i).getNumberOfPins() - 1; j >= 0; j--) {
                     CLOCK.low();
                     if (brailleList.get(i).getPinState(j) == true) {

--- a/src/enamel/TactilePlayer.java
+++ b/src/enamel/TactilePlayer.java
@@ -69,8 +69,6 @@ public class TactilePlayer extends Player {
     public TactilePlayer(int brailleCellNumber, int buttonNumber) throws SecurityException, IOException {
 
         super(brailleCellNumber, buttonNumber);
-        if (brailleCellNumber > 1 || buttonNumber > 4)
-            throw new IllegalArgumentException("The current system for TactilePlayer does not support more than 1 braille cell or more than 4 buttons");
         try {
             GpioController gpio = GpioFactory.getInstance();
             ON = gpio.provisionDigitalOutputPin(RaspiPin.GPIO_00, "ON", PinState.LOW);


### PR DESCRIPTION
# Description
I've added code to support multiple hardware braille cells. This was done by removing the exception that was thrown when a scenario file has more than 1 braille cell on a TBB environment, as well as changing the refresh method for TactilePlayer. This method was never tested before, as we've never had multiple physical braille cells! It works correctly to support both single and multiple braille cells.
A consequence of this is that a scenario containing multiple braille cells will now play on a single-cell device, but display only the first letter in a string (e.g., "c" will show when the command disp-string "cat" is in the scenario). 

## Changed
Changed the refresh method in TactilePlayer to work with both single and multiple braille cells. 

## Removed
Removed the exception that checks for the exception. 