### PR TITLE
Fix/logging scalp scenarios

### DIFF
--- a/src/enamel/SCALP.java
+++ b/src/enamel/SCALP.java
@@ -129,26 +129,8 @@ public class SCALP {
         main.voice.setRate(150f);
         main.voice.allocate();
         
-        //File Handler for logging scenarios chosen
-        FileHandler fileHandler = null; 
-		try {
-			Path path = Paths.get(System.getProperty("user.dir") + File.separator + "logs");
-			if(!Files.exists(path)) Files.createDirectory(path);
-			fileHandler = new FileHandler(System.getProperty("user.dir") + File.separator + "logs" + File.separator + "userScenarios.log.txt", fileSizeLimit, 1, true);
-		} catch (IOException e) {
-			e.printStackTrace();
-	         System.err.println("An error has occurred while creating the log files, please contact an administrator." + System.getProperty("line.separator") + "Error type: IOException.");
-		}
-        fileHandler.setFormatter(new Formatter() {
-    		private String format = "[%1$s] [%2$s] %3$s %n";
-			private SimpleDateFormat dateWithMillis = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss.SSS");
-			@Override
-			public String format(LogRecord record) {
-				return String.format(format, dateWithMillis.format(new Date()), record.getSourceClassName(), formatMessage(record));
-			}
-    	});
-    	main.logger.addHandler(fileHandler);
-    	main.logger.setUseParentHandlers(false);
+        //File Handler for logging scenarios chosen by user
+        main.fileHanderInit();
         
         //Ensure the arguments are not empty. 
         if (args.length == 0) {
@@ -335,17 +317,6 @@ public class SCALP {
             }   
         });
         
-//        //This holds the SCALP to wait for button input from hardware buttons
-//        //THIS IS A TEMPORARY FIX UNTIL REPO IS MERGED W/ SUNNY'S CODE
-//        //TODO: REMOVE AFTER REPO MERGE
-//        try {
-//        	while(true) 			
-//            	Thread.sleep(500);	
-//        }
-//        catch(InterruptedException e) {
-//        	e.printStackTrace();
-//        	System.out.println("Error while holding thread");
-//        }
         
     }
     
@@ -592,4 +563,27 @@ public class SCALP {
      void speak(String message) {
        voice.speak(message);
     }
+     
+     private void fileHanderInit() {
+    	 
+    	 FileHandler fileHandler = null; 
+ 		try {
+ 			Path path = Paths.get(System.getProperty("user.dir") + File.separator + "logs");
+ 			if(!Files.exists(path)) Files.createDirectory(path);
+ 			fileHandler = new FileHandler(System.getProperty("user.dir") + File.separator + "logs" + File.separator + "userScenarios.log.txt", fileSizeLimit, 1, true);
+ 		} catch (IOException e) {
+ 			e.printStackTrace();
+ 	         System.err.println("An error has occurred while creating the log files, please contact an administrator." + System.getProperty("line.separator") + "Error type: IOException.");
+ 		}
+         fileHandler.setFormatter(new Formatter() {
+     		private String format = "[%1$s] [%2$s] %3$s %n";
+ 			private SimpleDateFormat dateWithMillis = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss.SSS");
+ 			@Override
+ 			public String format(LogRecord record) {
+ 				return String.format(format, dateWithMillis.format(new Date()), record.getSourceClassName(), formatMessage(record));
+ 			}
+     	});
+     	this.logger.addHandler(fileHandler);
+     	this.logger.setUseParentHandlers(false);
+     }
 }


### PR DESCRIPTION
# Description
<!-- Summarize your PR here. Think "what, why, how." Bonus points for including an estimate of how long this PR will take to read, review, and test. -->
What: Add logging in to SCALP to keep track of which scenarios the user has selected.
Why: This will allow us better tracking of the user's interaction with SCALP and navigating potential errors.
How: A logger and file handler have been added.

PR review time: 15-30 minutes
PR testing time: 15-30 minutes

## Added
<!-- What features, code, or content did you add in this PR, if any? For this section as well as the Changed/Removed sections, use bullet points to stay concise. Remove any sections that you leave empty. -->
- Added a logger
- Added a file handler
- Added a method to initialize the file handler with logger (Line 566 - 588)
- Added a constant to represent maximum log file size (Line 123)
- Added scenario logging call directly after user has chosen scenario (Line 462)

## Changed
<!-- Did you make any changes to existing functionality? -->
-Nothing.

## Removed
<!-- Are you removing any functionality as part of this PR? -->
-Nothing.

# How should this be manually tested?
<!-- Write concise (ideally numbered) steps that reviewers can take to validate this PR. Include any necessary setup and teardown. -->

1. Create tester class inside the enamel package with a main method
2. Populate main method with following code:
		args = new String[2];
		args[0] = "START_FACTORY";
		args[1] = \\\*INSERT ABSOLUTE PATH TO FACTORY SCENARIOS HERE\*\\; 
		SCALP.main(args);
3. Determine absolute path to factory scenarios
4. Replace commented block with absolute path.
5. Run tester and follow prompts.
6. Select any scenario
7. Check logs directory for "userScenarios.log.txt"
8. Confirm log file has been updated with recent scenario.
9. Remove tester class