### PR TITLE
Fix/switching between Players

### DIFF
--- a/src/enamel/SCALP.java
+++ b/src/enamel/SCALP.java
@@ -500,20 +500,44 @@ public class SCALP {
     void startPlayer(String path){
         if (hardwareAvailable) {
             removeHWButtons();
+            new Thread(new Runnable() {
+                public void run() {
+                    ScenarioParser s;
+    				s = new ScenarioParser();
+    				 voice.deallocate();
+    				 System.out.println();
+    				 s.setScenarioFile(path, !hardwareAvailable);
+                   
+                }
+            }).start();
         }
         else {
             frame.setVisible(false);
             frame.dispose();
+            new Thread(new Runnable() {
+                public void run() {
+                    ScenarioParser s;
+    				s = new ScenarioParser();
+    				 voice.deallocate();
+    				 System.out.println();
+    				 s.setScenarioFile(path, !hardwareAvailable);
+                   
+                }
+            }).start();
+            //TODO: Create separate thread that starts in each if branch, one that calls
+            // the regular scenacrio parser, and one that calls the visual player one.
+            // This will ensure both scalp and the authoring app can use the visual or tactile
         }
-        new Thread(new Runnable() {
+/*        new Thread(new Runnable() {
             public void run() {
                 ScenarioParser s;
 				s = new ScenarioParser();
 				 voice.deallocate();
+				 System.out.println();
 				 s.setScenarioFile(path);
                
             }
-        }).start();
+        }).start();*/
     }
     
     /**

--- a/src/enamel/SCALP.java
+++ b/src/enamel/SCALP.java
@@ -500,44 +500,21 @@ public class SCALP {
     void startPlayer(String path){
         if (hardwareAvailable) {
             removeHWButtons();
-            new Thread(new Runnable() {
-                public void run() {
-                    ScenarioParser s;
-    				s = new ScenarioParser();
-    				 voice.deallocate();
-    				 System.out.println();
-    				 s.setScenarioFile(path, !hardwareAvailable);
-                   
-                }
-            }).start();
         }
         else {
             frame.setVisible(false);
             frame.dispose();
-            new Thread(new Runnable() {
-                public void run() {
-                    ScenarioParser s;
-    				s = new ScenarioParser();
-    				 voice.deallocate();
-    				 System.out.println();
-    				 s.setScenarioFile(path, !hardwareAvailable);
-                   
-                }
-            }).start();
-            //TODO: Create separate thread that starts in each if branch, one that calls
-            // the regular scenacrio parser, and one that calls the visual player one.
-            // This will ensure both scalp and the authoring app can use the visual or tactile
         }
-/*        new Thread(new Runnable() {
+        new Thread(new Runnable() {
             public void run() {
                 ScenarioParser s;
 				s = new ScenarioParser();
 				 voice.deallocate();
 				 System.out.println();
-				 s.setScenarioFile(path);
+				 s.setScenarioFile(path, !hardwareAvailable);
                
             }
-        }).start();*/
+        }).start();
     }
     
     /**

--- a/src/enamel/ScenarioParser.java
+++ b/src/enamel/ScenarioParser.java
@@ -700,7 +700,29 @@ public class ScenarioParser
         {
             cellNum = Integer.parseInt(fileScanner.nextLine().split("\\s")[1]);
             buttonNum = Integer.parseInt(fileScanner.nextLine().split("\\s")[1]);
-			sim = new TactilePlayer (cellNum, buttonNum);				           
+			sim = new TactilePlayer (cellNum, buttonNum);
+        }
+        catch (Exception e)
+        {
+            
+            errorLog ("Exception error: " + e.toString (), "Expected format: Cell num1 \n Button num2 \n " +
+            "as the first two lines of the scenarion file, and where num1 and num2 are positive integers. \n"
+            + "Did not receive such a format in the scenario file and program had to end due to the incorrect"
+            + "file format.");
+        }
+    }
+    
+    /*
+     * This method initializes the simulator class, by interpreting the first two lines of the scenario file
+     * to indicate the number of cells and number of JButtons, respectively.
+     */
+    private void setCellAndButtonVisual () 
+    {
+        try
+        {
+            cellNum = Integer.parseInt(fileScanner.nextLine().split("\\s")[1]);
+            buttonNum = Integer.parseInt(fileScanner.nextLine().split("\\s")[1]);
+			sim = new VisualPlayer (cellNum, buttonNum);
         }
         catch (Exception e)
         {
@@ -737,4 +759,33 @@ public class ScenarioParser
         }
     }
     
+
+    /*
+     * This method plays the scenario file specified by the argument. 
+     * The argument can be specified either as an absolute or a relative path.
+     */
+    public void setScenarioFile (String scenarioFile, boolean playType) 
+    {
+    	try
+    	{
+
+    		File f = new File (scenarioFile);
+    		fileScanner = new Scanner (f);
+    		String absolutePath = f.getAbsolutePath();
+    		scenarioFilePath = absolutePath.substring(0,absolutePath.lastIndexOf(File.separator));
+    		if(playType) 
+    			setCellAndButtonVisual();
+    		else
+    			setCellAndButton();
+    		play();
+    	}
+    	catch (Exception e)
+    	{
+    		errorLog ("Exception error: " + e.toString(), "Expected the directory path of the scenario file to"
+    				+ " a file exists in the project folder. \n Could not find directory to path: " + scenarioFile 
+    				+ " \n Perhaps" + " you forgot to add the file to the directory or "
+    				+ " you are looking for a different directory?");
+    	}
+    }
+
 }

--- a/src/listeners/TestListener.java
+++ b/src/listeners/TestListener.java
@@ -103,8 +103,8 @@ public class TestListener implements ActionListener {
 
 		 playerThread = new Thread("Player Thread") {
 		    public void run(){    
-		        ScenarioParser s = new ScenarioParser();        
-				s.setScenarioFile(scenarioFile.getAbsolutePath());
+		        ScenarioParser s = new ScenarioParser();
+				s.setScenarioFile(scenarioFile.getAbsolutePath(), true);
 		    }
 		};
 		playerThread.start();


### PR DESCRIPTION
# Description
<!-- Summarize your PR here. Think "what, why, how." Bonus points for including an estimate of how long this PR will take to read, review, and test. -->

What: Added 2 new methods to allow dynamic switching between the VisualPlayer and TactilePlayer

Why: The Authoring App also uses ScenarioParser and setScenarioFile to create the
visual player for the user. Now the players will be instantiated as required by the situation.

How: One of the new methods is an overloaded version of setScenarioFile
method. The boolean value passed calls the other new method setCellAndButtonVisual, to
instantiate the VisualPlayer, or the original setCellAndButton which instantiates the TactilePlayer.
Respectively, passing true or false will call these methods.
I left the original setScenario method because it is being used by the ToyAuthoring class.


## Added
<!-- What features, code, or content did you add in this PR, if any? For this section as well as the Changed/Removed sections, use bullet points to stay concise. Remove any sections that you leave empty. -->

- Method: setScenarioFile(scenarioFile, playType)
- Method: setCellAndButtonVisual()

## Changed
<!-- Did you make any changes to existing functionality? -->
- Changed relevant setScenarioFile calls to new type.

# How should this be manually tested?
<!-- Write concise (ideally numbered) steps that reviewers can take to validate this PR. Include any necessary setup and teardown. -->

**Authoring App Testing**

1. Run Authoring App
2. Create Arbitrary Test Scenario
3. Click test Scenario.

If the simulator run then the changes work.

**SCALP Visual Sim Testing**

1.  Create Test class with main method.
2. Insert the following code:
		args = new String[2];
		args[0] = "START_FACTORY";
		args[1] = "//Insert absolute path to scenario files";
		SCALP.main(args);
3. Run Test class

if the visualPlayer runs then the code works, and can conclude the tactilePlayer 
also works.